### PR TITLE
set Calico version hard-coded

### DIFF
--- a/lib.Makefile
+++ b/lib.Makefile
@@ -207,7 +207,8 @@ ifeq ($(GIT_USE_SSH),true)
 endif
 
 # Get version from git.
-GIT_VERSION:=$(shell git describe --tags --dirty --always --abbrev=12)
+# NeuReality - override the version from git
+GIT_VERSION:="v3.28.1"
 
 # Figure out version information.  To support builds from release tarballs, we default to
 # <unknown> if this isn't a git checkout.


### PR DESCRIPTION
Calico node build uses git tags to calculate the version of Calico. Calico version is set in ClusterInformation during runtime.
If the nodes do not agree on the Calico version, they can start some migration process or fail.

We have to either manipulate git tags or set the version of Calico explicitly. It seems manipulating git tags is not easy to use, especially for PRs, so the easier way is to set the version of Calico explicitly.